### PR TITLE
Adding verification of test support

### DIFF
--- a/coremark/base_test_results/test1/verify
+++ b/coremark/base_test_results/test1/verify
@@ -1,0 +1,3 @@
+iteration:threads:test\spasses
+1:[[:digit:]]{1,}:[0-9.]{1,}$
+1:[[:digit:]]{1,}:[0-9.]{1,}$

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -41,7 +41,7 @@ if [ ! -f "/tmp/${test_name}.out" ]; then
 	rtc=$?
 	cat /tmp/${test_name}.out
 	rm /tmp/${test_name}.out
-	exit $?
+	exit $rtc
 fi
 
 curdir=`pwd`
@@ -247,8 +247,8 @@ generate_results()
 		produce_report run1
 		produce_report run2
 	else
-		echo Summnary not supported yet when doing cpu counts > run1_summary
-		echo Summnary not supported yet when doing cpu counts > run2_summary
+		echo Summary not supported yet when doing cpu counts > run1_summary
+		echo Summary not supported yet when doing cpu counts > run2_summary
 	fi
 
 	if [ $to_pbench -eq 0 ]; then
@@ -283,7 +283,9 @@ install_test_tools "$@"
 # to_tuned_setting: tuned setting
 #
 
+pushd $curdir 2> /dev/null
 source $curdir/test_tools/general_setup "$@"
+popd 2> /dev/null
 # Gather hardware information
 $curdir/test_tools/gather_data ${curdir}
 

--- a/coremark/verification_config/test_verify
+++ b/coremark/verification_config/test_verify
@@ -1,0 +1,4 @@
+Required_Systems: intel,amd,arm
+Via_Zathras: No
+test:--iterations 1:base_test_results/test1/verify
+


### PR DESCRIPTION
# Description
Adds the pieces required to perform verification of the test.

# Before/After Comparison
Before this change: there was no validation of the test data.

After this change: the validation now uses the verification code for verifying the code produced valid output.  This will be extended into the general run in a later submit.

# Clerical Stuff

This closes #46 

Relates to JIRA: RPOPC-346
