### PR TITLE
Remove pbench support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ General options
   --home_parent <value>: Our parent home directory.  If not set, defaults to current working directory.
   --host_config <value>: default is the current host name.
   --iterations <value>: Number of times to run the test, defaults to 1.
-  --pbench: use pbench-user-benchmark and place information into pbench, defaults to do not use.
-  --pbench_user <value>: user who started everything. Defaults to the current user.
-  --pbench_copy: Copy the pbench data, not move it.
-  --pbench_stats: What stats to gather. Defaults to all stats.
   --run_label: the label to associate with the pbench run. No default setting.
   --run_user: user that is actually running the test on the test system. Defaults to user running wrapper.
   --sys_type: Type of system working with, aws, azure, hostname.  Defaults to hostname.
@@ -34,5 +30,3 @@ General options
     RHEL systems, default is none.
   --usage: this usage message.
 ```
-
-Note: The script does not install pbench for you.  You need to do that manually.

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -252,15 +252,13 @@ generate_results()
 		echo Summary not supported yet when doing cpu counts > run2_summary
 	fi
 
-	if [ $to_pbench -eq 0 ]; then
-		lines=`wc -l $results_file | cut -d' ' -f1`
-		if [ $lines -lt 2 ]; then
-			echo Failed > test_results_report
-		else
-			echo Ran > test_results_report
-		fi
-		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --other_files "*_summary,run*log,test_results_report" --results $results_file --test_name coremark --tuned_setting=$to_tuned_setting --version $coremark_version --user $to_user
+	lines=`wc -l $results_file | cut -d' ' -f1`
+	if [ $lines -lt 2 ]; then
+		echo Failed > test_results_report
+	else
+		echo Ran > test_results_report
 	fi
+	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --other_files "*_summary,run*log,test_results_report" --results $results_file --test_name coremark --tuned_setting=$to_tuned_setting --version $coremark_version --user $to_user
 	popd > /dev/null
 }
 
@@ -385,21 +383,8 @@ fi
 numb_cpus=`nproc`
 pushd coremark > /dev/null
 
-if [ $to_pbench -eq 1 ]; then
-        source ~/.bashrc
-	cd $curdir
-	#
-	# Arguments to pbecnh, change as required.
-	#
-	pbench_args="--cmd_executing \"$0\" $arguments --test ${test_name} --spacing 11 --pbench_stats $to_pstats"
-        echo $TOOLS_BIN/execute_via_pbench ${pbench_args}
-        $TOOLS_BIN/execute_via_pbench ${pbench_args}
-	if  [ $? -ne 0 ]; then
-		exit_out "Error: $TOOLS_BIN/execute_via_pbench ${pbench_args}" 1
-	fi
-else
-	run_coremark
-	generate_results
-fi
+run_coremark
+generate_results
+
 exit 0
 

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -22,7 +22,6 @@
 # set of default run parameters based on the system configuration.
 #
 
-pbench_arg_list=""
 commit="none"
 coremark_version="v1.01"
 test_name="coremark"
@@ -312,17 +311,14 @@ eval set --$opts
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 		--commit)
-			pbench_arg_list="${pbench_arg_list} $1 $2"
 			commit=$2
 			shift 2
 		;;
 		--cpu_add)
-			pbench_arg_list="${pbench_arg_list} $1 $2"
 			cpu_add=$2
 			shift 2
 		;;
 		--powers_2)
-			pbench_arg_list="${pbench_arg_list} $1"
 			powers_2=1
 			shift 1
 		;;

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -271,9 +271,6 @@ install_test_tools "$@"
 # to_home_root: home directory
 # to_configuration: configuration information
 # to_times_to_run: number of times to run the test
-# to_pbench: Run the test via pbench
-# to_pbench_copy: Copy the data to the pbench repository, not move_it.
-# to_puser: User running pbench
 # to_run_label: Label for the run
 # to_user: User on the test system running the test
 # to_sys_type: for results info, basically aws, azure or local


### PR DESCRIPTION
# Description
This PR removes pbench support from the coremark wrapper
 - Eliminates call to "execute_via_pbench"
 - Removes addition of arguments to pbench command
 - Removes documentation of pbench options, including README

# Before/After Comparison
Before: The pbench support code is present but can't do anything as support for pbench has been removed from the parent harness
After: pbench support and associated documentation is removed from the wrapper

# Clerical Stuff
This closes #55 
Relates to JIRA: RPOPC-578
