### PR TITLE
Use the new method of validation.

### DIFF
--- a/coremark/base_test_results/test1/verify
+++ b/coremark/base_test_results/test1/verify
@@ -1,3 +1,0 @@
-iteration:threads:test\spasses
-1:[[:digit:]]{1,}:[1-9][0-9.]{1,}$
-1:[[:digit:]]{1,}:[1-9][0-9.]{1,}$

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -28,6 +28,7 @@ coremark_version="v1.01"
 test_name="coremark"
 results_file="results_${test_name}.csv"
 arguments="$@"
+rtc=0
 
 exit_out()
 {
@@ -253,13 +254,10 @@ generate_results()
 	fi
 
 	if [ $to_pbench -eq 0 ]; then
-		lines=`wc -l $results_file | cut -d' ' -f1`
-		if [ $lines -lt 2 ]; then
-			echo Failed > test_results_report
-		else
-			echo Ran > test_results_report
-		fi
-		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --other_files "*_summary,run*log,test_results_report" --results $results_file --test_name coremark --tuned_setting=$to_tuned_setting --version $coremark_version --user $to_user
+		$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${results_file} --output_file ${test_name}.json
+		$TOOLS_BIN/verify_results $to_verify_flags --file ${test_name}.json --schema_file $to_script_dir/result_schema.py --class_name CoremarkResults
+		rtc=$?
+		${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --other_files "*json,*_summary,run*log,test_results_report" --results $results_file --test_name coremark --tuned_setting=$to_tuned_setting --version $coremark_version --user $to_user
 	fi
 	popd > /dev/null
 }
@@ -401,5 +399,4 @@ else
 	run_coremark
 	generate_results
 fi
-exit 0
-
+exit $rtc

--- a/coremark/result_schema.py
+++ b/coremark/result_schema.py
@@ -1,0 +1,5 @@
+import pydantic
+class CoremarkResults(pydantic.BaseModel):
+        iteration: int = pydantic.Field(description="Iteration", gt=0)
+        threads: int = pydantic.Field(description="How many threads we ran.", gt=0)
+        test_passes: float = pydantic.Field(description="Number of test passes", allow_inf_nan=False, gt=0, validation_alias="test passes")

--- a/coremark/verification_config/test_verify
+++ b/coremark/verification_config/test_verify
@@ -1,4 +1,0 @@
-Required_Systems: intel,amd,arm
-Via_Zathras: No
-test:--iterations 1:base_test_results/test1/verify
-


### PR DESCRIPTION
# Description
Replaces regexp validation with json/python.

# Before/After Comparison
Before: We used grep and regexps.  Difficult to maintain.
After:  Using json/python for validation, much easier to maintain.

# Clerical Stuff
This closes #58


Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-581
