### PR TITLE
Changed CSV metric heading from "test passes" to "iters/sec".

### DIFF
--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -216,7 +216,7 @@ run_coremark()
 	done
 	$TOOLS_BIN/test_header_info --front_matter --results_file $results_file --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $coremark_version --test_name $test_name
 
-	echo "iteration:threads:iters/sec" >> $results_file
+	echo "iteration:threads:IterationsPerSec" >> $results_file
 	sort -n $csv_file >> $results_file
 	rm $csv_file
 }

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -216,7 +216,7 @@ run_coremark()
 	done
 	$TOOLS_BIN/test_header_info --front_matter --results_file $results_file --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $coremark_version --test_name $test_name
 
-	echo "iteration:threads:test passes" >> $results_file
+	echo "iteration:threads:iters/sec" >> $results_file
 	sort -n $csv_file >> $results_file
 	rm $csv_file
 }

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -243,7 +243,7 @@ produce_report()
 				total_time=`echo ${total_time}+${value} | bc`
 				continue
 			fi
-			if [[ $line == "Iterations/sec"* ]]; then
+			if [[ $line == "IterationsPerSec"* ]]; then
 				value=`echo $line | cut -d':' -f2 | sed "s/ //g"`
 				iterations=`echo ${iterations}+${value} | bc`
 				continue


### PR DESCRIPTION
# Description
This PR changes the name of the test metric from "test passes" to "iters/sec" to reflect the fact that the result being reported is the number of iterations per second.

# Before/After Comparison
## Before
```
...
# Test general meta end
iteration:threads:test passes
1:160:3263973.888209
...
```
## After
```
...
# Test general meta end
iteration:threads:iters/sec
1:160:3114052.160374
...
```


# Clerical Stuff
This closes #62 

Relates to JIRA: RPOPC-616
