### PR TITLE
Convert to pydantic validation

### DIFF
--- a/coremark/base_test_results/test1/verify
+++ b/coremark/base_test_results/test1/verify
@@ -1,3 +1,0 @@
-iteration:threads:test\spasses
-1:[[:digit:]]{1,}:[1-9][0-9.]{1,}$
-1:[[:digit:]]{1,}:[1-9][0-9.]{1,}$

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -27,6 +27,7 @@ coremark_version="v1.01"
 test_name="coremark"
 results_file="results_${test_name}.csv"
 arguments="$@"
+script_dir=$(realpath $(dirname $0))
 
 exit_out()
 {
@@ -417,6 +418,9 @@ if [[ $to_use_pcp -eq 1 ]]; then
 fi
 
 run_coremark
+
+$TOOLS_BIN/csv_to_json $to_json_flags --csv_file ${results_file} --output_file results_coremark.json
+$TOOLS_BIN/verify_results $to_verify_flags --schema_file $script_dir/../result_schema.py --class_name CoremarkResults --file results_coremark.json
 
 # Shutdown PCP and clean up after ourselves
 if [[ $to_use_pcp -eq 1 ]]; then

--- a/coremark/verification_config/test_verify
+++ b/coremark/verification_config/test_verify
@@ -1,4 +1,0 @@
-Required_Systems: intel,amd,arm
-Via_Zathras: No
-test:--iterations 1:base_test_results/test1/verify
-

--- a/result_schema.py
+++ b/result_schema.py
@@ -1,0 +1,6 @@
+import pydantic
+
+class CoremarkResults(pydantic.BaseModel):
+    iteration: int = pydantic.Field(gt=0)
+    threads: int = pydantic.Field(gt=0)
+    IterationsPerSec: float = pydantic.Field(gt=0, allow_inf_nan=False)


### PR DESCRIPTION
# Description
Instead of using fragile regular expression logic to validate test results, pydantic allows for much more maintainable methods.

Presently the validation looks for:
- iteration > 0
- threads > 0
- IterationsPerSec > 0.0 (can't be NaN or inf)

# Before/After Comparison
## Before
Validation code was using regular expressions, which are hard to maintain and liable to breaking in ways hard to understand.

## After
Validation code uses pydantic, which is much simpler and easier to understand.

# Clerical Stuff
Closes #58 

Relates to JIRA: RPOPC-581


## CSV Output
```
# Test general meta start
# Test: coremark
# Results version: v1.01
# Host: --sys_type
# Sys environ: None
# Tuned: tuned_none
# OS: 6.18.3-200.fc43.x86_64
# Numa nodes: 1
# CPU family: AMD Ryzen 7 PRO 7840HS w/ Radeon 780M Graphics
# Number cpus: 16
# Memory: 64420248kB
# Test general meta end
iteration:threads:IterationsPerSec
1:16:352578.228294
1:16:376323.010584
```

## Run log
[coremark.log](https://github.com/user-attachments/files/24571450/coremark.log)


