### PR TITLE
Adding in pcp metricsfor test.

### DIFF
--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -139,7 +139,7 @@ execute_coremark()
 
 	#If we're using PCP, snap a chalk line at the start of the iteration
 	if [[ $to_use_pcp -eq 1 ]]; then
-        	start_pcp_subset
+		start_pcp_subset
 	fi
 
 	make -s XCFLAGS="${make_flags}"
@@ -151,13 +151,21 @@ execute_coremark()
 	# and log the iteration's result
 
 	if [[ $to_use_pcp -eq 1 ]]; then
-        	test_iters=`grep "Iterations/" run1.log | cut -d':' -f2 | sed "s/ //g"`
-		results2pcp_add_value "iteration":${iter}"
-		results2pcp_add_value "numthreads":${numthreads}"
-		results2pcp_add_value "IterationsPerSec":${test_iters}
+		test_iters=`grep "Iterations/" run1.log | cut -d':' -f2 | sed "s/ //g"`
+		results2pcp_add_value "iteration:${iter}"
+		results2pcp_add_value "runlog:1"
+		results2pcp_add_value "numthreads:${numthreads}"
+		results2pcp_add_value "IterationsPerSec:${test_iters}"
 		results2pcp_add_value_commit
 		reset_pcp_om
-	        stop_pcp_subset
+		test_iters=`grep "Iterations/" run2.log | cut -d':' -f2 | sed "s/ //g"`
+		results2pcp_add_value "iteration:${iter}"
+		results2pcp_add_value "runlog:2"
+		results2pcp_add_value "numthreads:${numthreads}"
+		results2pcp_add_value "IterationsPerSec:${test_iters}"
+		results2pcp_add_value_commit
+		reset_pcp_om
+		stop_pcp_subset
 	fi
 
 	#
@@ -416,9 +424,8 @@ $curdir/test_tools/package_tool --no_packages $to_no_pkg_install --wrapper_confi
 # Get PCP setup if we're using it
 if [[ $to_use_pcp -eq 1 ]]; then
 	source $TOOLS_BIN/pcp/pcp_commands.inc
-	ls ${run_dir}/openmetrics_${test_name}_reset.txt
-        setup_pcp
-        pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+	setup_pcp
+	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
 	pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
 fi
 

--- a/coremark/openmetrics_coremark_reset.txt
+++ b/coremark/openmetrics_coremark_reset.txt
@@ -4,4 +4,5 @@ numthreads 0
 runtime NaN
 throughput NaN
 latency NaN
+runlog NaN
 IterationsPerSec NaN


### PR DESCRIPTION
# Description
Has test place the results into the pcp openmetric file

# Before/After Comparison
Metrics only appeared in the csv file

Now test metrics appears in both the csv file and the openmetric file

# Clerical Stuff
This closes #66 

Relates to JIRA: RPOPC-772

Test Results

Command run
/home/ec2-user/workloads/coremark-wrapper/coremark/coremark_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m5.xlarge" --sysname "m5.xlarge" --sys_type aws --use_pcp

CSV file
iiteration:threads:IterationsPerSec
1:4:58590.889117
1:4:59627.329193

pcp snippet
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.IterationsPerSec  o.w.runlog
18:56:04          0.000        1.000           0.000          NaN             NaN          NaN                   NaN         NaN
18:56:05          1.000        1.000           4.000          NaN             NaN          NaN             58590.889       1.000
18:56:06          1.000        1.000           4.000          NaN             NaN          NaN             58590.889       1.000
18:56:07          0.000        0.000           0.000          NaN             NaN          NaN                   NaN         NaN
18:56:08          0.000        0.000           0.000          NaN             NaN          NaN                   NaN         NaN
18:56:09          1.000        0.000           4.000          NaN             NaN          NaN             59627.329       2.000

-x output
[coremark.txt](https://github.com/user-attachments/files/24748593/coremark.txt)


