### PR TITLE
Fix test_tools directory

### DIFF
--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -72,13 +72,16 @@ show_usage=0
 cpu_add=0
 powers_2=0
 
+TOOLS_BIN="$HOME/test_tools"
+export TOOLS_BIN
+
 usage()
 {
 	echo "Usage $1:"
 	echo "  --commit <n>: git commit to use, default is the tag ${coremark_version}"
 	echo "  --cpu_add <n>: starting at cpu count of 1, add this number of cpus to each run"
 	echo "  --powers_2s: starting at 1, run the number of cpus by powers of 2's"
-	source $HOME/test_tools/general_setup --usage
+	source $TOOLS_BIN/general_setup --usage
 	exit 0
 }
 
@@ -112,8 +115,8 @@ install_test_tools()
 	# Check to see if the test tools directory exists.  If it does, we do not need to
 	# clone the repo.
 	#
-	if [ ! -d "$HOME/test_tools" ]; then
-		git clone $tools_git $HOME/test_tools
+	if [ ! -d "$TOOLS_BIN" ]; then
+		git clone $tools_git "$TOOLS_BIN"
 		if [ $? -ne 0 ]; then
 			exit_out "Error: pulling git $tools_git failed." 1
 		fi
@@ -343,7 +346,7 @@ install_test_tools "$@"
 #
 
 pushd $curdir 2> /dev/null
-source $HOME/test_tools/general_setup "$@"
+source "$TOOLS_BIN/general_setup" "$@"
 popd 2> /dev/null
 # Gather hardware information
 $TOOLS_BIN/gather_data ${curdir}


### PR DESCRIPTION
### **User description**
# Description
This PR sets the test_tools directory to `$HOME/test_tools` so the common utilities are in a well-known location.

Additionally, this converts the package_tool call to use the convience function, which includes several flags parsed by `general_setup`.

# Before/After Comparison
## Before
The test tools would be cloned to wherever the `coremark_run` script was located.

## After
The test tools are now located at `$HOME/test_tools`

# Clerical Stuff
Closes #71 
Relates to JIRA: RPOPC-829


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Standardize test_tools location to `$HOME/test_tools` directory

- Replace hardcoded paths with `TOOLS_BIN` environment variable

- Convert `package_tool` call to use convenience function

- Improve path handling with proper quoting for shell safety


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded test_tools paths"] -- "Replace with TOOLS_BIN variable" --> B["Centralized $HOME/test_tools location"]
  C["Direct package_tool call"] -- "Use convenience function" --> D["Simplified package_tool invocation"]
  B --> E["Improved portability and maintainability"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coremark_run</strong><dd><code>Centralize test_tools path with TOOLS_BIN variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

coremark/coremark_run

<ul><li>Added <code>TOOLS_BIN="$HOME/test_tools"</code> variable definition and export at <br>script start<br> <li> Replaced all hardcoded <code>$curdir/test_tools</code> paths with <code>$TOOLS_BIN</code> <br>variable throughout script<br> <li> Updated <code>install_test_tools()</code> to clone to <code>$TOOLS_BIN</code> instead of <br>relative <code>test_tools</code> directory<br> <li> Converted <code>package_tool</code> call to use convenience function without full <br>path prefix<br> <li> Added proper quoting around variable references for shell safety</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-performance/coremark-wrapper/pull/70/files#diff-48ef11c9c524d853b268dd5be333c04b95af1251a130402430e632f5b17ff243">+11/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

