### PR TITLE
Update error codes to be more specific.

### DIFF
--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -114,7 +114,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." $E_GENERAL
+                        exit_out "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -97,7 +97,7 @@ attempt_tools_wget()
         fi
 }
 
-attetmpt_tools_curl()
+attempt_tools_curl()
 {
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 curl -L -O ${tools_git}/archive/refs/heads/main.zip
@@ -150,7 +150,7 @@ install_test_tools()
 	# clone the repo.
 	#
 	attempt_tools_wget
-	attetmpt_tools_curl
+	attempt_tools_curl
 	attempt_tools_git
 
 	if [ $show_usage -eq 1 ]; then

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -85,6 +85,40 @@ usage()
 	exit 0
 }
 
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attetmpt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 1
+                fi
+        fi
+}
+
 install_test_tools()
 {
 	#
@@ -115,12 +149,9 @@ install_test_tools()
 	# Check to see if the test tools directory exists.  If it does, we do not need to
 	# clone the repo.
 	#
-	if [ ! -d "$TOOLS_BIN" ]; then
-		git clone $tools_git "$TOOLS_BIN"
-		if [ $? -ne 0 ]; then
-			exit_out "Error: pulling git $tools_git failed." 1
-		fi
-	fi
+	attempt_tools_wget
+	attetmpt_tools_curl
+	attempt_tools_git
 
 	if [ $show_usage -eq 1 ]; then
 		usage $1

--- a/coremark/coremark_run
+++ b/coremark/coremark_run
@@ -82,7 +82,7 @@ usage()
 	echo "  --cpu_add <n>: starting at cpu count of 1, add this number of cpus to each run"
 	echo "  --powers_2s: starting at 1, run the number of cpus by powers of 2's"
 	source $TOOLS_BIN/general_setup --usage
-	exit 0
+	exit $E_USAGE
 }
 
 attempt_tools_wget()
@@ -114,7 +114,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 1
+                        exit_out "Error: pulling git $tools_git failed." $E_GENERAL
                 fi
         fi
 }
@@ -197,7 +197,7 @@ execute_coremark()
 	add_time_to_run_log run1.log "$cm_start_time" "$cm_end_time"
 	add_time_to_run_log run2.log "$cm_start_time" "$cm_end_time"
 	if [ $? -ne 0 ]; then
-		exit_out "Failed: make XCFLAGS=\"${make_flags}\"" 1
+		exit_out "Failed: make XCFLAGS=\"${make_flags}\"" $E_GENERAL
 	fi
 
 	# If we're using PCP, snap the chalk line at the end of the iteration
@@ -434,7 +434,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ $powers_2 -ne 0 ] && [ $cpu_add -ne 0 ]; then
-	exit_out "Error, can not designate both cpu_add and powers_2" 1
+	exit_out "Error, can not designate both cpu_add and powers_2" $E_GENERAL
 fi
 
 if [ -d /${to_home_root}/${to_user} ]; then
@@ -455,17 +455,17 @@ else
 	if [[ $commit == "none" ]]; then
 		GIT_TERMINAL_PROMPT=0 git clone --depth 1 --branch ${coremark_version} https://github.com/eembc/coremark
 		if [ $? -ne 0 ]; then
-			exit_out "Failed: git clone --depth 1 --branch ${coremark_version} https://github.com/eembc/coremark" 1
+			exit_out "Failed: git clone --depth 1 --branch ${coremark_version} https://github.com/eembc/coremark" $E_GENERAL
 		fi
 	else
 		GIT_TERMINAL_PROMPT=0 git clone https://github.com/eembc/coremark
 		if [ $? -ne 0 ]; then
-			exit_out "Failed: git clone https://github.com/eembc/coremark" 1
+			exit_out "Failed: git clone https://github.com/eembc/coremark" $E_GENERAL
 		fi
 		pushd coremark > /dev/null
 		GIT_TERMINAL_PROMPT=0 git checkout ${commit}
 		if [ $? -ne 0 ]; then
-			exit_out "Failed: git checkout ${commit}" 1
+			exit_out "Failed: git checkout ${commit}" $E_GENERAL
 		fi
 		popd > /dev/null
 	fi
@@ -496,5 +496,4 @@ fi
 
 generate_results
 
-exit 0
-
+exit $E_SUCCESS


### PR DESCRIPTION
# Description
Uses error_codes found in test_tools/error_codes to provide more specific error indication.

# Before/After Comparison
Before: Returned a 0 or 1, making determination of having to rerun very course
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
           Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not 
           being installed.

# Clerical Stuff
This closes #72 

Relates to JIRA: RPOPC-867

Testing

Ran through zathras, with following scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: documentation
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "coremark"
    host_config: "m5.xlarge"


csv file produced.
iteration,threads,IterationsPerSec,Start_Date,End_Date
1,4,58708.414873,2026-03-13T12:11:27Z,2026-03-13T12:12:18Z
1,4,59802.651251,2026-03-13T12:11:27Z,2026-03-13T12:12:18Z
2,4,58927.519151,2026-03-13T12:12:33Z,2026-03-13T12:13:23Z
2,4,59769.885939,2026-03-13T12:12:33Z,2026-03-13T12:13:23Z
3,4,59017.360940,2026-03-13T12:13:38Z,2026-03-13T12:14:28Z
3,4,59488.399762,2026-03-13T12:13:38Z,2026-03-13T12:14:28Z
4,4,58783.188008,2026-03-13T12:14:43Z,2026-03-13T12:15:34Z
4,4,59627.329193,2026-03-13T12:14:43Z,2026-03-13T12:15:34Z
5,4,58924.625583,2026-03-13T12:15:48Z,2026-03-13T12:16:39Z
5,4,60003.000150,2026-03-13T12:15:48Z,2026-03-13T12:16:39Z

Returned 0 as expected.  Testing on rerun verification handled in the appropriate zathras pr.

