### PR TITLE
Add azure pkgs

### DIFF
--- a/coremark.json
+++ b/coremark.json
@@ -35,6 +35,18 @@
       "git",
       "zip"
     ],
+    "azure": [
+      "bc",
+      "numactl",
+      "perf",
+      "unzip",
+      "make",
+      "sed",
+      "gawk",
+      "gcc",
+      "git",
+      "zip"
+    ],
     "sles": [
       "bc",
       "libnuma1",

--- a/coremark.json
+++ b/coremark.json
@@ -35,7 +35,7 @@
       "git",
       "zip"
     ],
-    "azure": [
+    "azurelinux": [
       "bc",
       "numactl",
       "perf",


### PR DESCRIPTION
# Description
Adding support for azurelinux

# Before/After Comparison
Before:  coremark would fail because azurelinux packages are not defined.
After: coremark runs successfully as it can install the packages.

# Clerical Stuff
This closes #78

Relates to JIRA: RPOPC-

Testing
Verified the test runs succesfully in the azure linux environment.

csv file
iteration,threads,IterationsPerSec,Start_Date,End_Date
1,4,79816.422229,2026-06-04T09:27:17Z,2026-06-04T09:28:06Z
1,4,80152.289350,2026-06-04T09:27:17Z,2026-06-04T09:28:06Z
2,4,79313.934467,2026-06-04T09:28:20Z,2026-06-04T09:29:09Z
2,4,80280.983442,2026-06-04T09:28:20Z,2026-06-04T09:29:09Z
3,4,79558.450599,2026-06-04T09:29:23Z,2026-06-04T09:30:12Z
3,4,79637.648698,2026-06-04T09:29:23Z,2026-06-04T09:30:12Z
4,4,79860.244572,2026-06-04T09:30:26Z,2026-06-04T09:31:14Z
4,4,79864.230808,2026-06-04T09:30:26Z,2026-06-04T09:31:14Z
5,4,79665.405298,2026-06-04T09:31:29Z,2026-06-04T09:32:17Z
5,4,80172.370597,2026-06-04T09:31:29Z,2026-06-04T09:32:17Z

pcp output: 
[coremark_pcp.txt](https://github.com/user-attachments/files/28590415/coremark_pcp.txt)

Zathras log:
[ansible_log.txt](https://github.com/user-attachments/files/28590698/ansible_log.txt)


